### PR TITLE
Peter/bad rtp mode

### DIFF
--- a/src/media/event.rs
+++ b/src/media/event.rs
@@ -1,7 +1,7 @@
 use std::ops::RangeInclusive;
 use std::time::Instant;
 
-use crate::rtp::{Direction, ExtensionValues, MediaTime, Mid, Pt, Rid, SeqNo, Ssrc};
+use crate::rtp::{Direction, ExtensionValues, MediaTime, Mid, Pt, Rid, SeqNo};
 use crate::sdp::Simulcast as SdpSimulcast;
 
 use super::PayloadParams;
@@ -97,9 +97,6 @@ pub struct MediaData {
     /// This is a newer standard that is sometimes used in WebRTC to identify
     /// a stream. Specifically when using Simulcast in Chrome.
     pub rid: Option<Rid>,
-
-    ///
-    pub ssrc: Option<Ssrc>,
 
     /// Parameters for the codec. This is used to match incoming PT to outgoing PT.
     pub params: PayloadParams,

--- a/src/media/inner.rs
+++ b/src/media/inner.rs
@@ -1321,7 +1321,7 @@ impl MediaInner {
         self.simulcast = Some(s);
     }
 
-    pub fn ssrc_rx_for_rid(&mut self, repairs: Option<Rid>, ignore_ssrc: Ssrc) -> Option<Ssrc> {
+    pub fn ssrc_rx_for_rid(&self, repairs: Option<Rid>, ignore_ssrc: Ssrc) -> Option<Ssrc> {
         // Find the most recent matching ssrc, in case the ssrc has changed.
         self.sources_rx
             .iter()

--- a/src/media/inner.rs
+++ b/src/media/inner.rs
@@ -1321,9 +1321,11 @@ impl MediaInner {
         self.simulcast = Some(s);
     }
 
+    // Finds the most recent non-rtx SSRC for the given RID and RTX SSRC. If RID is None, it will
+    // find the most recent non-rtx SSRC without an assigned RID.
     pub fn find_primary_ssrc_for_rid(&self, repairs: Option<Rid>, rtx_ssrc: Ssrc) -> Option<Ssrc> {
-        // Find the most recent matching ssrc, in case the ssrc has changed. We ignore sources with
-        // repairs, as those are RTX, and we ignore ourselves.
+        // Note: We still need to make sure we don't return the rtx_ssrc, because the associated
+        // source for rtx_ssrc may not have repairs set, and hence not be aware it is for RTX.
         self.sources_rx
             .iter()
             .rfind(|r| r.rid() == repairs && r.ssrc() != rtx_ssrc && !r.is_rtx())

--- a/src/media/inner.rs
+++ b/src/media/inner.rs
@@ -1246,7 +1246,6 @@ impl MediaInner {
                         mid: self.mid,
                         pt: *pt,
                         rid: *rid,
-                        ssrc: dep.meta.get(0).map(|meta| meta.header.ssrc),
                         params: codec,
                         time: dep.time,
                         network_time: dep.first_network_time(),

--- a/src/media/inner.rs
+++ b/src/media/inner.rs
@@ -1321,11 +1321,12 @@ impl MediaInner {
         self.simulcast = Some(s);
     }
 
-    pub fn ssrc_rx_for_rid(&self, repairs: Option<Rid>, ignore_ssrc: Ssrc) -> Option<Ssrc> {
-        // Find the most recent matching ssrc, in case the ssrc has changed.
+    pub fn find_primary_ssrc_for_rid(&self, repairs: Option<Rid>, rtx_ssrc: Ssrc) -> Option<Ssrc> {
+        // Find the most recent matching ssrc, in case the ssrc has changed. We ignore sources with
+        // repairs, as those are RTX, and we ignore ourselves.
         self.sources_rx
             .iter()
-            .rfind(|r| r.rid() == repairs && r.ssrc() != ignore_ssrc)
+            .rfind(|r| r.rid() == repairs && r.ssrc() != rtx_ssrc && r.repairs().is_none())
             .map(|r| r.ssrc())
     }
 

--- a/src/media/inner.rs
+++ b/src/media/inner.rs
@@ -1322,10 +1322,11 @@ impl MediaInner {
         self.simulcast = Some(s);
     }
 
-    pub fn ssrc_rx_for_rid(&self, repairs: Rid) -> Option<Ssrc> {
+    pub fn ssrc_rx_for_rid(&self, repairs: Option<Rid>, ignore_ssrc: Ssrc) -> Option<Ssrc> {
+        // Find the most recent matching ssrc, in case the ssrc has changed.
         self.sources_rx
             .iter()
-            .find(|r| r.rid() == Some(repairs))
+            .rfind(|r| r.rid() == repairs && r.ssrc() != ignore_ssrc)
             .map(|r| r.ssrc())
     }
 

--- a/src/media/inner.rs
+++ b/src/media/inner.rs
@@ -1321,7 +1321,7 @@ impl MediaInner {
         self.simulcast = Some(s);
     }
 
-    pub fn ssrc_rx_for_rid(&self, repairs: Option<Rid>, ignore_ssrc: Ssrc) -> Option<Ssrc> {
+    pub fn ssrc_rx_for_rid(&mut self, repairs: Option<Rid>, ignore_ssrc: Ssrc) -> Option<Ssrc> {
         // Find the most recent matching ssrc, in case the ssrc has changed.
         self.sources_rx
             .iter()

--- a/src/media/inner.rs
+++ b/src/media/inner.rs
@@ -1326,7 +1326,7 @@ impl MediaInner {
         // repairs, as those are RTX, and we ignore ourselves.
         self.sources_rx
             .iter()
-            .rfind(|r| r.rid() == repairs && r.ssrc() != rtx_ssrc && r.repairs().is_none())
+            .rfind(|r| r.rid() == repairs && r.ssrc() != rtx_ssrc && !r.is_rtx())
             .map(|r| r.ssrc())
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -466,7 +466,7 @@ impl Session {
                     return;
                 }
             };
-            trace!("Repaired {:?} -> {:?}", header.ssrc, repaired_ssrc);
+            trace!("Repaired ssrc {:?} -> {:?}", header.ssrc, repaired_ssrc);
             header.ssrc = repaired_ssrc;
 
             let repaired_source = media.get_or_create_source_rx(repaired_ssrc);
@@ -475,11 +475,19 @@ impl Session {
             }
             let orig_seq_no = repaired_source.update(now, &header, clock_rate);
 
-            let params = media.get_params(header.payload_type).unwrap();
-            if Some(header.payload_type) == params.resend() {
-                // Update Payload type to match the original.
-                header.payload_type = params.pt;
-            }
+            let params = match media.get_params(header.payload_type) {
+                Some(v) => v,
+                None => {
+                    trace!("Can't find payload parameters for: {}", header.payload_type);
+                    return;
+                }
+            };
+            trace!(
+                "Repaired payload type {:?} -> {:?}",
+                header.payload_type,
+                params.pt
+            );
+            header.payload_type = params.pt;
 
             orig_seq_no
         } else {

--- a/src/session.rs
+++ b/src/session.rs
@@ -383,9 +383,12 @@ impl Session {
             }
         };
 
-        // Figure out which SSRC the repairs header points out. This is here because of borrow
-        // checker ordering.
-        let rid_repair = header.ext_vals.rid_repair;
+        // Figure out the repair SSRC. Prefer the RID repair header, but fallback to the
+        // last RID values for the source.
+        let rid_repair = header
+            .ext_vals
+            .rid_repair
+            .or_else(|| media.get_or_create_source_rx(ssrc).rid());
         let ssrc_repairs = media.ssrc_rx_for_rid(rid_repair, ssrc);
 
         let source = media.get_or_create_source_rx(ssrc);

--- a/src/session.rs
+++ b/src/session.rs
@@ -386,30 +386,34 @@ impl Session {
         let source = media.get_or_create_source_rx(ssrc);
 
         let mut media_need_check_source = false;
-        if let Some(rid) = header.ext_vals.rid {
+
+        // Obtain the rid supplied in the header, if any
+        let supplied_rid = if is_rtx {
+            header.ext_vals.rid_repair
+        } else {
+            header.ext_vals.rid
+        };
+
+        // Determine the source rid, and update if one was supplied
+        let rid = if let Some(rid) = supplied_rid {
             if source.set_rid(rid) {
                 media_need_check_source = true;
             }
-        }
+            supplied_rid
+        } else {
+            source.rid()
+        };
 
         // Gymnastics to appease the borrow checker.
         let source = if is_rtx {
-            // For RTX, we will look for the associated repair ssrc using the RID, if we have one.
-            // Prefer the RID repair header, if supplied, but fallback to the last RID values for
-            // the source.
-            let rid_repair = header.ext_vals.rid_repair.or_else(|| source.rid());
-            let ssrc_repairs = media.find_primary_ssrc_for_rid(rid_repair, ssrc);
+            // For RTX, we will look for the associated repair ssrc using the last RID seen
+            // on our source.
+            let primary_ssrc = media.find_primary_ssrc_for_rid(rid, ssrc);
 
             let source = media.get_or_create_source_rx(ssrc);
 
-            // The rid_repair header may not be sent on every packet, so we need to remember the
-            // RID for this source in the future.
-            if let Some(rid) = rid_repair {
-                _ = source.set_rid(rid);
-            }
-
-            if let Some(ssrc_repairs) = ssrc_repairs {
-                if source.set_repairs(ssrc_repairs) {
+            if let Some(primary_ssrc) = primary_ssrc {
+                if source.set_repairs(primary_ssrc) {
                     media_need_check_source = true;
                 }
             } else if source.repairs().is_none() {
@@ -429,7 +433,6 @@ impl Session {
             source
         };
 
-        let mut rid = source.rid();
         let seq_no = source.update(now, &header, clock_rate);
 
         let mut data = match srtp.unprotect_rtp(buf, &header, *seq_no) {
@@ -462,9 +465,6 @@ impl Session {
                 orig_seq_16
             );
             header.sequence_number = orig_seq_16;
-            if let Some(repairs_rid) = header.ext_vals.rid_repair {
-                rid = Some(repairs_rid);
-            }
 
             let repaired_ssrc = match source.repairs() {
                 Some(v) => v,
@@ -477,9 +477,6 @@ impl Session {
             header.ssrc = repaired_ssrc;
 
             let repaired_source = media.get_or_create_source_rx(repaired_ssrc);
-            if rid.is_none() && repaired_source.rid().is_some() {
-                rid = repaired_source.rid();
-            }
             let orig_seq_no = repaired_source.update(now, &header, clock_rate);
 
             let params = match media.get_params(header.payload_type) {

--- a/src/session.rs
+++ b/src/session.rs
@@ -398,11 +398,18 @@ impl Session {
             // Prefer the RID repair header, if supplied, but fallback to the last RID values for
             // the source.
             let rid_repair = header.ext_vals.rid_repair.or_else(|| source.rid());
-            let repairs = media.ssrc_rx_for_rid(rid_repair, ssrc);
+            let ssrc_repairs = media.find_primary_ssrc_for_rid(rid_repair, ssrc);
 
             let source = media.get_or_create_source_rx(ssrc);
-            if let Some(repairs) = repairs {
-                if source.set_repairs(repairs) {
+
+            // The rid_repair header may not be sent on every packet, so we need to remember the
+            // RID for this source in the future.
+            if let Some(rid) = rid_repair {
+                _ = source.set_rid(rid);
+            }
+
+            if let Some(ssrc_repairs) = ssrc_repairs {
+                if source.set_repairs(ssrc_repairs) {
                     media_need_check_source = true;
                 }
             } else if source.repairs().is_none() {

--- a/src/session.rs
+++ b/src/session.rs
@@ -416,8 +416,8 @@ impl Session {
                 if source.set_repairs(primary_ssrc) {
                     media_need_check_source = true;
                 }
-            } else if source.repairs().is_none() {
-                trace!("Ignoring RTX since we could not find an associated SSRC");
+            } else {
+                trace!("Ignoring RTX packet because the we could not find an associated ssrc");
                 return;
             }
             source

--- a/src/session.rs
+++ b/src/session.rs
@@ -445,9 +445,10 @@ impl Session {
 
             let n = RtpHeader::read_original_sequence_number(&data, &mut orig_seq_16);
             data.drain(0..n);
-            info!(
+            trace!(
                 "Repaired seq no {} -> {}",
-                header.sequence_number, orig_seq_16
+                header.sequence_number,
+                orig_seq_16
             );
             header.sequence_number = orig_seq_16;
             if let Some(repairs_rid) = header.ext_vals.rid_repair {
@@ -461,7 +462,7 @@ impl Session {
                     return;
                 }
             };
-            info!("Repaired {:?} -> {:?}", header.ssrc, repaired_ssrc);
+            trace!("Repaired {:?} -> {:?}", header.ssrc, repaired_ssrc);
             header.ssrc = repaired_ssrc;
 
             let repaired_source = media.get_or_create_source_rx(repaired_ssrc);


### PR DESCRIPTION
- Revert ssrc exposure, since it is unneeded.
- Change ssrc_rx_for_rid
  -  Support Option<Rid>
  - Take an Ssrc to ignore self
  - Use rfind() to prefer more recent ssrcs in case we reassign
 - Determine is_rtx by payload type
 - Fix payload type to be the non-resend payload type when "repairing" the packet
 - In rtp_mode update the RTP header to match the "repaired" packet.